### PR TITLE
fix test_fib VLAN_MEMBER on t1 testbed

### DIFF
--- a/tests/common/fixtures/ptfhost_utils.py
+++ b/tests/common/fixtures/ptfhost_utils.py
@@ -172,6 +172,11 @@ def ptf_portmap_file(duthosts, rand_one_dut_hostname, ptfhost):
 @pytest.fixture(scope="session", autouse=True)
 def run_icmp_responder(duthost, ptfhost, tbinfo):
     """Run icmp_responder.py over ptfhost."""
+    # No vlan is avaliable on non-t0 testbed, so skip this fixture
+    if 't0' not in tbinfo['topo']['type']:
+        yield
+        return
+
     logger.debug("Copy icmp_responder.py to ptfhost '{0}'".format(ptfhost.hostname))
     ptfhost.copy(src=os.path.join(SCRIPTS_SRC_DIR, ICMP_RESPONDER_PY), dest=OPT_DIR)
 


### PR DESCRIPTION
Description of PR
Summary:
This PR is to fix test_fib on t1 testbed.
Recent PR #3502 imports autoused fixture run_icmp_responder. However, this fixture doesn't work on non-t0 testbed because VLAN_MEMBER doesn't exist in running config.

    def get_vlan_intfs(self):
        '''
        Get any interfaces belonging to a VLAN
        '''
>       vlan_members_facts = self.get_running_config_facts()['VLAN_MEMBER']
E       KeyError: 'VLAN_MEMBER'