### PR TITLE
fix hash_test fail because hash keys ip-proto

### DIFF
--- a/tests/fib/test_fib.py
+++ b/tests/fib/test_fib.py
@@ -445,6 +445,11 @@ def hash_keys(duthost):
             hash_keys.remove('ip-proto')
         if 'ingress-port' in hash_keys:
             hash_keys.remove('ingress-port')
+    # removing ip-proto from hash_keys for bcm56996, spec no support info
+    if "brixia" in duthost.facts['platform']:
+        if 'ip-proto' in hash_keys:
+            hash_keys.remove('ip-proto')
+
     # remove the ingress port from multi asic platform
     # In multi asic platform each asic has different hash seed,
     # the same packet coming in different asic


### PR DESCRIPTION

### Description of PR


Summary:   在做hash key为 ip-proto的测试的时候，ecmp的值超过了0.25的误差设定，并且芯片稳定中没有明确定义ip-proto的ecmp
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
