### PR TITLE
fix DHCP relay

### DIFF
--- a/tests/dhcp_relay/test_dhcp_relay.py
+++ b/tests/dhcp_relay/test_dhcp_relay.py
@@ -126,7 +126,7 @@ def restart_dhcp_service(duthost):
 
     for retry in range(5):
         time.sleep(30)
-        dhcp_status = duthost.shell('docker container top dhcp_relay | grep dhcrelay | cat')["stdout"]
+        dhcp_status = duthost.shell('docker container top dhcp_relay | grep dhcp_relay | cat')["stdout"]
         if dhcp_status != "":
             break
     else:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix DHCP relay test failure
Fixes # (issue)
http://10.204.112.27:8081/job/brixia-t1/9/testReport/dhcp_relay.test_dhcp_pkt_fwd/
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

`root@server2-container1:/var/clsnet/echo/SWITCH/SONiC/celestica-fb/sonic-mgmt/tests# ./run_tests.sh -d cel-brixia-01 -n server2_brixia_t1 -c dhcp_relay/ -u
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
================================================================================================================================== test session starts ===================================================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /var/clsnet/echo/SWITCH/SONiC/celestica-fb/sonic-mgmt/tests, inifile: pytest.ini
plugins: metadata-1.11.0, forked-1.3.0, html-1.22.1, xdist-1.28.0, repeat-0.9.1, ansible-2.2.2
collected 14 items

dhcp_relay/test_dhcp_pkt_fwd.py::TestDhcpPktFwd::testDhcpPacketForwarding[pktInfo0] PASSED                                                                                                                                                                                         [  7%]
dhcp_relay/test_dhcp_pkt_fwd.py::TestDhcpPktFwd::testDhcpPacketForwarding[pktInfo1] PASSED                                                                                                                                                                                         [ 14%]
dhcp_relay/test_dhcp_pkt_fwd.py::TestDhcpPktFwd::testDhcpPacketForwarding[pktInfo2] PASSED                                                                                                                                                                                         [ 21%]
dhcp_relay/test_dhcp_pkt_fwd.py::TestDhcpPktFwd::testDhcpPacketForwarding[pktInfo3] PASSED                                                                                                                                                                                         [ 28%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default[single] PASSED                                                                                                                                                                                                              [ 35%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_after_link_flap[single] PASSED                                                                                                                                                                                                      [ 42%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_start_with_uplinks_down[single] PASSED                                                                                                                                                                                              [ 50%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_unicast_mac[single] PASSED                                                                                                                                                                                                          [ 57%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_random_sport[single] PASSED                                                                                                                                                                                                         [ 64%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default[dual] PASSED                                                                                                                                                                                                                [ 71%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_after_link_flap[dual] PASSED                                                                                                                                                                                                        [ 78%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_start_with_uplinks_down[dual] PASSED                                                                                                                                                                                                [ 85%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_unicast_mac[dual] PASSED                                                                                                                                                                                                            [ 92%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_random_sport[dual] PASSED                                                                                                                                                                                                           [100%]

---------------------------------------------------------------------------------------------- generated xml file: /var/clsnet/echo/SWITCH/SONiC/celestica-fb/sonic-mgmt/tests/logs/tr.xml -----------------------------------------------------------------------------------------------
============================================================================================================================== 14 passed in 260.30 seconds ===============================================================================================================================
Exception AttributeError: "'NoneType' object has no attribute 'close'" in <bound method EventDescriptor.__del__ of <ptf.ptfutils.EventDescriptor instance at 0x7f98ec93e5f0>> ignored
root@server2-container1:/var/clsnet/echo/SWITCH/SONiC/celestica-fb/sonic-mgmt/tests#`
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
