### PR TITLE
Updated the portmap for list variable-src_ports to match the topo

### DIFF
--- a/ansible/roles/test/files/ptftests/dir_bcast_test.py
+++ b/ansible/roles/test/files/ptftests/dir_bcast_test.py
@@ -55,7 +55,7 @@ class BcastTest(BaseTest):
         self.router_mac = self.test_params['router_mac']
         self.setUpVlan(self.test_params['vlan_info'])
         if self.test_params['testbed_type'] == 't0':
-            self.src_ports = range(1, 25) + range(28, 31)
+            self.src_ports = range(1, 25) + range(27, 31)
         if self.test_params['testbed_type'] == 't0-52':
             self.src_ports = range(0, 52)
         if self.test_params['testbed_type'] == 't0-64':

--- a/ansible/roles/test/files/ptftests/dir_bcast_test.py
+++ b/ansible/roles/test/files/ptftests/dir_bcast_test.py
@@ -55,7 +55,7 @@ class BcastTest(BaseTest):
         self.router_mac = self.test_params['router_mac']
         self.setUpVlan(self.test_params['vlan_info'])
         if self.test_params['testbed_type'] == 't0':
-            self.src_ports = range(1, 25) + range(28, 32)
+            self.src_ports = range(1, 25) + range(28, 31)
         if self.test_params['testbed_type'] == 't0-52':
             self.src_ports = range(0, 52)
         if self.test_params['testbed_type'] == 't0-64':


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Updated the portmap for list variable-src_ports to match the topo

Fixes # (issue)

Test_Log:
root@ef1005272b58:/home/george/sonic-mgmt/tests# ./run_tests.sh -d cel-brixia2-01 -n server2_brixia2_t0 -t t0,any -c ipfwd/test_dir_bcast.py -u
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/_init_.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
from cryptography.exceptions import InvalidSignature
================================================== test session starts ===================================================
platform linux2 – Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /home/george/sonic-mgmt/tests, inifile: pytest.ini
plugins: metadata-1.11.0, forked-1.3.0, html-1.22.1, xdist-1.28.0, repeat-0.9.1, ansible-2.2.2
collected 1 item

ipfwd/test_dir_bcast.py::test_dir_bcast PASSED [100%]

----------------------------- generated xml file: /home/george/sonic-mgmt/tests/logs/tr.xml ------------------------------
=============================================== 1 passed in 34.80 seconds ================================================
root@ef1005272b58:/home/george/sonic-mgmt/tests#

root@999ab8257412:/tmp# cat dir_bcast.BcastTest.2021-08-10-07:21:15.log
07:31:11.482  root      : INFO    : ++++++++ Tue Aug 10 07:31:11 2021 ++++++++
07:31:11.529  scapy.runtime: WARNING : No route found for IPv6 destination :: (no default route?)
07:31:11.557  root      : INFO    : VXLAN support found in Scapy
07:31:11.557  root      : INFO    : ERSPAN support found in Scapy
07:31:11.558  root      : INFO    : GENEVE support found in Scapy
07:31:11.558  root      : INFO    : MPLS support found in Scapy
07:31:11.558  root      : INFO    : NVGRE support found in Scapy
07:31:11.718  root      : INFO    : Importing platform: remote
07:31:11.719  root      : INFO    : port map: {(0, 22): 'eth22', (0, 27): 'eth27', (0, 0): 'eth0', (0, 20): 'eth20', (0, 25): 'eth25', (0, 14): 'eth14', (0, 18): 'eth18', (0, 7): 'eth7', (0, 12): 'eth12', (0, 16): 'eth16', (0, 5): 'eth5', (0, 10): 'eth10', (0, 30): 'eth30', (0, 3): 'eth3', (0, 8): 'eth8', (0, 23): 'eth23', (0, 28): 'eth28', (0, 1): 'eth1', (0, 21): 'eth21', (0, 26): 'eth26', (0, 15): 'eth15', (0, 19): 'eth19', (0, 24): 'eth24', (0, 13): 'eth13', (0, 17): 'eth17', (0, 6): 'eth6', (0, 11): 'eth11', (0, 4): 'eth4', (0, 9): 'eth9', (0, 29): 'eth29', (0, 2): 'eth2'}
07:31:11.719  root      : INFO    : Autogen random seed: 48015026
07:31:11.746  root      : INFO    : *** TEST RUN START: Tue Aug 10 07:31:11 2021
07:31:11.750  root      : INFO    : Sending packet from port 27 to 192.168.7.255
07:31:13.691  root      : INFO    : Received 24 broadcast packets, expecting 24
07:31:13.703  root      : INFO    : Sending BOOTP packet from port 27 to 192.168.7.255
07:31:14.717  root      : INFO    : Received 24 broadcast BOOTP packets, expecting 24
07:31:14.718  root      : INFO    : ** END TEST CASE dir_bcast_test.BcastTest
07:31:14.718  root      : INFO    : *** TEST RUN END  : Tue Aug 10 07:31:14 2021
07:31:14.718  dataplane : INFO    : Thread exit

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
