### PR TITLE
Enhance code logic to match more topo

### DIFF
--- a/tests/read_mac/test_read_mac_metadata.py
+++ b/tests/read_mac/test_read_mac_metadata.py
@@ -111,11 +111,17 @@ class ReadMACMetadata():
             pytest.fail("MAC entry does not exist")
 
         logger.info("Verify interfaces are UP and MTU == 9100")
-        checks.check_interfaces(duthost)
 
+        check_interfaces  = self.request.getfixturevalue('check_interfaces')
+        check_interfaces(duthost)
+        
         cfg_facts = duthost.config_facts(host=duthost.hostname, source="persistent")['ansible_facts']
-        non_default_ports = [k for k,v in cfg_facts["PORT"].items() if "mtu" in v and v["mtu"] != "9100" and "admin_status" in v and v["admin_status"] == "up" ]
-        non_default_portchannel = [k for k,v in cfg_facts["PORTCHANNEL"].items() if "mtu" in v and v["mtu"] != "9100" and "admin_status" in v and v["admin_status"] == "up" ]
+        non_default_ports = []
+        non_default_portchannel = []
+        if "port" in cfg_facts:
+            non_default_ports = [k for k,v in cfg_facts["PORT"].items() if "mtu" in v and v["mtu"] != "9100" and "admin_status" in v and v["admin_status"] == "up" ]
+        if "PORTCHANNEL" in cfg_facts:
+            non_default_portchannel = [k for k,v in cfg_facts["PORTCHANNEL"].items() if "mtu" in v and v["mtu"] != "9100" and "admin_status" in v and v["admin_status"] == "up" ]
 
         if len(non_default_ports) != 0 or len(non_default_portchannel) != 0:
             pytest.fail("There are ports/portchannel with non default MTU:\nPorts: {}\nPortchannel: {}".format(non_default_ports,non_default_portchannel))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 
Enhance code logic to match different topo;
Grammar problem about pytest fixture
循环升级，每升级一次，读取配置文件中 MAC Address 信息

Fixes # (issue)
root@sonic037:/home/gary/sonic-mgmt_brixia2/tests# ./run_tests.sh -d cel-brixia2-01 -n server2_brixia2_t1 -t t1,any -c read_mac/test_read_mac_metadata.py -u -e --iteration=2 -e --image2=http://10.204.112.155:8081/sonic/brixia/sonic-broadcom-202012-gitlab.bin -e --minigraph1=/home/gary/minigraph_1.xml -e --image1=http://10.204.112.155:8081/sonic/brixia/sonic-broadcom-813.bin -e --minigraph2=/home/gary/minigraph_1.xml
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/_init_.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
from cryptography.exceptions import InvalidSignature
================================================== test session starts ===================================================
platform linux2 – Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /home/gary/sonic-mgmt_brixia2/tests, inifile: pytest.ini
plugins: metadata-1.11.0, forked-1.3.0, html-1.22.1, xdist-1.28.0, repeat-0.9.1, ansible-2.2.2
collected 1 item

read_mac/test_read_mac_metadata.py::test_read_mac_metadata[cel-brixia2-01] PASSED [100%]

-------------------------- generated xml file: /home/gary/sonic-mgmt_brixia2/tests/logs/tr.xml ---------------------------
============================================== 1 passed in 1208.25 seconds ===============================================
root@sonic037:/home/gary/sonic-mgmt_brixia2/tests#

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
