### PR TITLE
Add brixia sensor info to fix sensor test

### DIFF
--- a/ansible/group_vars/sonic/sku-sensors-data.yml
+++ b/ansible/group_vars/sonic/sku-sensors-data.yml
@@ -3209,6 +3209,26 @@ sensors_checks:
       temp: []
     psu_skips: {}
 
+  x86_64-cel_brixia-r0:
+    alarms:
+      fan: []
+      power: []
+      temp:
+      - coretemp-isa-0000/Core 0/temp2_crit_alarm
+      - coretemp-isa-0000/Core 1/temp3_crit_alarm
+      - coretemp-isa-0000/Core 2/temp4_crit_alarm
+      - coretemp-isa-0000/Core 3/temp5_crit_alarm
+      - coretemp-isa-0000/Core 4/temp6_crit_alarm
+      - coretemp-isa-0000/Core 5/temp7_crit_alarm
+      - coretemp-isa-0000/Core 6/temp8_crit_alarm
+      - coretemp-isa-0000/Core 7/temp9_crit_alarm
+    compares: {}
+    non_zero:
+      fan: []
+      power: []
+      temp: []
+    psu_skips: {}
+
   x86_64-arista_7050_qx32s:
     alarms:
       fan:


### PR DESCRIPTION

### Description of PR
修复platform test_sensor 在brixia上面的fail case，
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
 ./run_tests.sh -d cel-brixia2-01 -n server2_brixia2_t0 -c platform_tests/test_sensors.py -t t0,any -u
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
========================================================================== test session starts ===========================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.10.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /home/clsnet/willwu/sonic-mgmt/tests, inifile: pytest.ini
plugins: metadata-1.11.0, forked-1.3.0, html-1.22.1, xdist-1.28.0, repeat-0.9.1, ansible-2.2.2
collected 1 item

platform_tests/test_sensors.py::test_sensors PASSED                    
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
