### PR TITLE
Add power cycle reboot support for brixia

### DIFF
--- a/ansible/TestbedProcessing.py
+++ b/ansible/TestbedProcessing.py
@@ -449,6 +449,19 @@ def makeLab(data, devices, testbed, outfile):
                                 entry += "\tos=" + operationsystem
                             except:
                                 print("\t\t" + host + ": device operation type not found")
+                            try: # get pdu_host
+                                pdu_host = devices.get(host.lower()).get("pdu_host")
+                                entry += "\tpdu_host=" + pdu_host
+                            except:
+                                print("\t\t" + host + ": pdu_host not found")
+                    if "pdu" in key:
+                        try: # get pdu protocol type default snmp
+                            protocoltype = devices.get(host.lower()).get("protocol")
+                            entry += "\tprotocol=" + protocoltype
+                        except:
+                            entry += "\tprotocol=snmp"
+                            print("\t\t" + host + ": pdu protocol type not found, set default snmp")
+
 
                     toWrite.write(entry + "\n")
                 toWrite.write("\n")

--- a/ansible/testbed-bristone2.yaml
+++ b/ansible/testbed-bristone2.yaml
@@ -30,14 +30,23 @@ device_groups:
         host: [brixia-fanout, seastone-fanout]
     ptf:
         host: [ptfbt0,ptfbt1,ptfst0,ptfst1,ptfsst0]
+    pdu:
+        host: [pdu-1]
 
 # devices is a dictionary that contains all devices and hosts but not ptfs (ptfs found under testbed)
 # devices is used to export sonic_lab_devices, fanout/secrets, lab/secrets, lab
 # there are no cross references
 devices:
+    pdu-1:
+        device_type: blank
+        hwsku: apc
+        protocol: snmp
+        ansible:
+            ansible_host: TODO-avoidattach
     cel-brixia-01:
         device_type: DevSonic
         hwsku: Brixia
+        pdu_host: pdu-1
         alias: 
         credentials:
             username: 

--- a/ansible/testbed-brixia2.yaml
+++ b/ansible/testbed-brixia2.yaml
@@ -30,14 +30,22 @@ device_groups:
         host: [brixia-fanout, arista-fanout]
     ptf:
         host: [ptfbt0,ptfbt1,ptfst0,ptfst1,ptfsst0]
-
+    pdu:
+        host: [pdu-1]
 # devices is a dictionary that contains all devices and hosts but not ptfs (ptfs found under testbed)
 # devices is used to export sonic_lab_devices, fanout/secrets, lab/secrets, lab
 # there are no cross references
 devices:
+    pdu-1:
+        device_type: blank
+        hwsku: apc
+        protocol: snmp
+        ansible:
+            ansible_host: TODO-avoidattach
     cel-brixia-01:
         device_type: DevSonic
         hwsku: Brixia
+        pdu_host: pdu-1
         alias: 
         credentials:
             username: 
@@ -69,6 +77,7 @@ devices:
     cel-brixia2-01:
         device_type: DevSonic
         hwsku: Brixia
+        pdu_host: pdu-1
         alias: 
         credentials:
             username: 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:   使能reboot的pdu控制逻辑， 防止网络attach, 真实ip地址没有提交，需要部署的时候手动填写。
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
