### PR TITLE
fix test_crm_route fail

### DIFF
--- a/tests/crm/test_crm.py
+++ b/tests/crm/test_crm.py
@@ -23,7 +23,7 @@ pytestmark = [
 logger = logging.getLogger(__name__)
 
 CRM_POLLING_INTERVAL = 1
-CRM_UPDATE_TIME = 4
+CRM_UPDATE_TIME = 10
 SONIC_RES_UPDATE_TIME = 50
 
 THR_VERIFY_CMDS = OrderedDict([
@@ -406,6 +406,10 @@ def get_entries_num(used, available):
     """ Get number of entries needed to be created that 'used' counter reached one percent """
     return ((used + available) / 100) + 1
 
+def get_route_entries_num(used, available):
+    """ Get number of entries needed to be created that 'used' counter reached one percent """
+    return (((used + available) / 100) + 1)- used
+
 @pytest.mark.usefixtures('disable_route_checker')
 @pytest.mark.parametrize("ip_ver,route_add_cmd,route_del_cmd", [("4", "{} route add 2.2.2.0/24 via {}",
                                                                 "{} route del 2.2.2.0/24 via {}"),
@@ -495,7 +499,7 @@ def test_crm_route(duthosts, enum_rand_one_per_hwsku_frontend_hostname, enum_fro
 
     used_percent = get_used_percent(new_crm_stats_route_used, new_crm_stats_route_available)
     if used_percent < 1:
-        routes_num = get_entries_num(new_crm_stats_route_used, new_crm_stats_route_available)
+        routes_num = get_route_entries_num(new_crm_stats_route_used, new_crm_stats_route_available)
         if ip_ver == "4":
             routes_list = " ".join([str(ipaddress.IPv4Address(u'2.0.0.1') + item) + "/32"
                 for item in range(1, routes_num + 1)])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
修复CRM测试失败
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
2021年10月13日的时候拿到新的SAI 6.0.0.2+HSDK 6.5.23实验CRM

这个版本修复了test_crm_nexthop_group和crm.test_crm.test_acl_entry但是test_crm_route会fail

#### How did you do it?

分析了一下是测试的过程中需要添加路由使已用的路由数目达到既定的阈值然后在syslog里面产生阈值告警的log，但是似乎ansible并不支持一次添加那么多参数（≈9898）

研究发现需要添加路由使已用的路由数目达到既定的阈值（1%）并不需要添加那么多路由（≈9898）
修改添加路由数目的算法函数
#### How did you verify/test it?
用Jenkins重新跑了一次测试，测试通过“brixia-t1/44/testReport/crm/test_crm/”
#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
T0,T1,ANY
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
