### PR TITLE
修复P2测试中的test_static_route.py::test_static_route_ecmp的bug

### DIFF
--- a/tests/route/test_static_route.py
+++ b/tests/route/test_static_route.py
@@ -104,6 +104,9 @@ def run_static_route_test(duthost, ptfadapter, ptfhost, tbinfo, prefix, nexthop_
         if config_reload_test:
             duthost.shell('config save -y')
             config_reload(duthost)
+            for idx in range(len(nexthop_addrs)):
+                duthost.shell("ping {} -c 10".format(nexthop_addrs[idx]))
+            time.sleep(5)
             generate_and_verify_traffic(duthost, ptfadapter, tbinfo, ip_dst, nexthop_devs, ipv6=ipv6)
 
     finally:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes 
brixia-p2/2/testReport/junit/route/test_static_route/test_static_route_ecmp

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
P2测试中ECMP测试会失败，且能稳定手动复现
#### How did you do it?
使用PDB调试，发现是因为DUT重启之后二层地址表丢失导致的失败，于是添加workaround在重新加载配置之后测试开始之前用ping的方式变相更新二层地址表
#### How did you verify/test it?
手动重新测试能稳定通过
#### Any platform specific information?
NO
#### Supported testbed topology if it's a new test case?
T0
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
