### PR TITLE
[Cfg] Remove default everflow cfg when deploy topology

### DIFF
--- a/ansible/templates/minigraph_dpg.j2
+++ b/ansible/templates/minigraph_dpg.j2
@@ -167,16 +167,6 @@
           <Type>SNMP</Type>
         </AclInterface>
         <AclInterface>
-          <AttachTo>ERSPAN</AttachTo>
-          <InAcl>Everflow</InAcl>
-          <Type>Everflow</Type>
-        </AclInterface>
-        <AclInterface>
-          <AttachTo>ERSPANV6</AttachTo>
-          <InAcl>EverflowV6</InAcl>
-          <Type>EverflowV6</Type>
-        </AclInterface>
-        <AclInterface>
           <AttachTo>VTY_LINE</AttachTo>
           <InAcl>ssh-only</InAcl>
           <Type>SSH</Type>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
everflow acl的配置在deploy topoloy时默认部署到DUT上，202106版本的SONiC当everflow acl配置失败时swss和syncd会异常退出，考虑移除默认everflow acl的配置来规避该问题。
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
按照commit修改文件后deploy topology，在dut上使用`show runningconfiguration all`查看是否有everflow的相关配置。

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
