### PR TITLE
fix fanout switch shell login error

### DIFF
--- a/ansible/testbed-bristone2.yaml
+++ b/ansible/testbed-bristone2.yaml
@@ -73,7 +73,7 @@ devices:
             fanout_sonic_password: password
             fanout_network_user: admin
             fanout_network_password: password
-            fanout_shell_user: admin
+            fanout_shell_user: root
             fanout_shell_password: password
 
     cel-seastone2-01:

--- a/ansible/testbed-brixia2.yaml
+++ b/ansible/testbed-brixia2.yaml
@@ -71,7 +71,7 @@ devices:
             fanout_sonic_password: password
             fanout_network_user: admin
             fanout_network_password: password
-            fanout_shell_user: admin
+            fanout_shell_user: root
             fanout_shell_password: password
 
     cel-brixia2-01:
@@ -105,7 +105,7 @@ devices:
             fanout_sonic_password: password
             fanout_network_user: admin
             fanout_network_password: password
-            fanout_shell_user: admin
+            fanout_shell_user: root
             fanout_shell_password: password
 
     str-celb-serv-020:


### PR DESCRIPTION
shell_user (string, optional): Username for accessing the Linux shell CLI interface

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
      if cb.unreachable:
>           raise AnsibleConnectionFailure("Host unreachable", dark=cb.unreachable, contacted=cb.contacted)
E           AnsibleConnectionFailure: Host unreachable

<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: 当用shell_user账号密码登录fanout的时候，想登录的是linux shell命令行，不是eos的命令行
Fixes # (issue)  修改用户名后登录正常，可以继续测试，在linux shell做操作.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
