### PR TITLE
fix platform_tests.link_flap fail

### DIFF
--- a/tests/platform_tests/link_flap/link_flap_utils.py
+++ b/tests/platform_tests/link_flap/link_flap_utils.py
@@ -142,7 +142,7 @@ def toggle_one_link(dut, dut_port, fanout, fanout_port, watch=False):
         logger.info("Bring up fanout switch %s port %s connecting to %s", fanout.hostname, fanout_port, dut_port)
         fanout.no_shutdown(fanout_port)
         need_recovery = False
-        pytest_assert(wait_until(30, 1, __check_if_status, dut, dut_port, 'up', True), "dut port {} didn't go up as expected".format(dut_port))
+        pytest_assert(wait_until(60, 1, __check_if_status, dut, dut_port, 'up', True), "dut port {} didn't go up as expected".format(dut_port))
     finally:
         if need_recovery:
             fanout.no_shutdown(fanout_port)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
修复{Jenkins}/job/brixia-t0/62-64/testReport/platform_tests.link_flap/
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
更换B0的DUT之后某台DUT的某些port link会变得比其他的稍微慢一些，导致测试失败。
#### How did you do it?

#### How did you verify/test it?
手动验证+Jenkins都能稳定passed
![image](https://user-images.githubusercontent.com/75826286/145504357-10b6b2bb-76c6-4dfd-b561-b90c13a40ab2.png)

#### Any platform specific information?
no
#### Supported testbed topology if it's a new test case?
any
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
