### PR TITLE
fix DUT config reload will not proceed if DUT not health

### DIFF
--- a/tests/common/config_reload.py
+++ b/tests/common/config_reload.py
@@ -37,6 +37,6 @@ def config_reload(duthost, config_source='config_db', wait=120, start_bgp=True, 
         duthost.shell('config save -y')
 
     if config_source == 'config_db':
-        duthost.shell('config reload -y &>/dev/null', executable="/bin/bash")
+        duthost.shell('config reload -y -f &>/dev/null', executable="/bin/bash")
 
     time.sleep(wait)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
修复
{Jenkins}/job/brixia-t0/61-63/testReport/dhcp_relay/
{Jenkins}job/brixia-t0/61-63/testReport/bgp/
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
tests/pc/test_po_cleanup.py 会停掉SWSS来测试port channel，然后使用config reload来恢复DUT。但是这个时候DUT会检查系统健康完整性，如果系统不是所有服务都正常的情况下将不能正常reload。导致跟在后面的测试失败
#### How did you do it?
随着对配置重载的系统检查的引入，如果系统不稳定，配置重载将不会进行。然而，sonic-mgmt 测试套件中的许多测试使用配置重新加载来恢复系统，以用于故意杀死或停止 docker 或进程的测试用例。因此，为了支持这些并且不对现有测试产生任何影响，config_reload API 将使用 -f 选项
#### How did you verify/test it?
{Jenkins}job/brixia-t0/65/
#### Any platform specific information?
NO
#### Supported testbed topology if it's a new test case?
ANY
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
