### PR TITLE
fix silverstone bgp speaker test fail dulto tcp service delay and fix pmon check process

### DIFF
--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -152,7 +152,7 @@ def common_setup_teardown(duthosts, rand_one_dut_hostname, ptfhost, localhost, t
     # check exabgp http_api port is ready
     http_ready = True
     for i in range(0, 3):
-        http_ready = wait_tcp_connection(localhost, ptfip, port_num[i], 60)
+        http_ready = wait_tcp_connection(localhost, ptfip, port_num[i])
         if not http_ready:
             break
 

--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -151,7 +151,10 @@ def common_setup_teardown(duthosts, rand_one_dut_hostname, ptfhost, localhost, t
 
     # check exabgp http_api port is ready
     http_ready = True
+    tcpinfo = ptfhost.shell('netstat -tunlp')
     for i in range(0, 3):
+        if str(port_num[i]) not in tcpinfo['stdout']:
+            time.sleep(30)
         http_ready = wait_tcp_connection(localhost, ptfip, port_num[i])
         if not http_ready:
             break

--- a/tests/bgp/test_bgp_speaker.py
+++ b/tests/bgp/test_bgp_speaker.py
@@ -151,11 +151,8 @@ def common_setup_teardown(duthosts, rand_one_dut_hostname, ptfhost, localhost, t
 
     # check exabgp http_api port is ready
     http_ready = True
-    tcpinfo = ptfhost.shell('netstat -tunlp')
     for i in range(0, 3):
-        if str(port_num[i]) not in tcpinfo['stdout']:
-            time.sleep(30)
-        http_ready = wait_tcp_connection(localhost, ptfip, port_num[i])
+        http_ready = wait_tcp_connection(localhost, ptfip, port_num[i], 60)
         if not http_ready:
             break
 

--- a/tests/common/devices/sonic.py
+++ b/tests/common/devices/sonic.py
@@ -516,7 +516,7 @@ class SonicHost(AnsibleHostBase):
         @return: dictionary of { service_name1 : state1, ... ... }
         """
         # some services are meant to have a short life span or not part of the daemons
-        exemptions = ['lm-sensors', 'start.sh', 'rsyslogd', 'start', 'dependent-startup']
+        exemptions = ['lm-sensors', 'start.sh', 'rsyslogd', 'start', 'dependent-startup', 'chassis_db_init']
 
         daemons = self.shell('docker exec pmon supervisorctl status', module_ignore_errors=True)['stdout_lines']
 

--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -81,7 +81,7 @@ def wait_until(timeout, interval, condition, *args, **kwargs):
         return False
 
 
-def wait_tcp_connection(client, server_hostname, listening_port, timeout_s = 30):
+def wait_tcp_connection(client, server_hostname, listening_port, timeout_s = 60):
     """
     @summary: Wait until tcp connection is ready or timeout
     @param client: The tcp client host instance


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:   http服务启动时间超过30秒
Fixes # (issue)， 判断是否准备好，还没启动的话等待30秒

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
