### PR TITLE
[Vrf] remove DATAACL acl entry when test case of ACL redirect

### DIFF
--- a/tests/vrf/vrf_restore_dataacl.json
+++ b/tests/vrf/vrf_restore_dataacl.json
@@ -1,0 +1,15 @@
+{
+    "ACL_TABLE": {
+        "DATAACL": {
+            "policy_desc": "DATAACL",
+            "ports": [
+                "PortChannel0001",
+                "PortChannel0002",
+                "PortChannel0003",
+                "PortChannel0004"
+            ],
+            "stage": "ingress",
+            "type": "L3"
+        }
+    }
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
SONiC has default ACL entries such as DATAACL, SNMP_ACL, SSH_ONLY. The DATAACL entry must be removed, otherwise the ACL redirect entry can not be installed.

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
